### PR TITLE
Clarify the provieded CSS is plain CSS in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Check [`package.json`](https://github.com/practical-computer/practical-error-han
 Include the utility CSS for hiding/showing messages, or [copy/paste into your codebase](https://github.com/practical-computer/practical-error-handling-js/blob/main/css/util.css):
 
 ```scss
-@use '@practical-computer/error-handling/css/util'
+@import '@practical-computer/error-handling/css/util.css'
 ```
 
 ## Quick Guide


### PR DESCRIPTION
> Still technically not standard due to bare import, but its bare minimum CSS, use @import, people will think its Sass otherwise.