### PR TITLE
Rename `applyErrorMappingToFormFromUnprocessableEntityResponseResponse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,13 +191,13 @@ We use the `aria-describedby` so that your markup is **accessible by default**. 
 Since each application has different needs, the best way to utilize the custom elements that wrap around a form to provide event handlers is to subclass them to make your own versions:
 
 ```js
-import { applyErrorMappingToFormFromUnprocessableEntityResponseResponse } from '@practical-computer/error-handling/request-processing'
+import { applyErrorMappingFromResponse } from '@practical-computer/error-handling/request-processing'
 
 class AppErrorHandlingElement extends ErrorHandlingElement {
   connectedCallback() {
     super.connectedCallback()
 
-    this.addEventListener(`custom-fetch-library:request-error`, applyErrorMappingToFormFromUnprocessableEntityResponseResponse)
+    this.addEventListener(`custom-fetch-library:request-error`, applyErrorMappingFromResponse)
 
     this.form.addEventListener(`submit`, (event) => {
       if(!event.defaultPrevented){
@@ -234,12 +234,12 @@ The provided request processing functions expect a `422` response to indicate th
 ### Using the basic request processing function
 
 ```js
-import { applyErrorMappingToFormFromUnprocessableEntityResponseResponse } from '@practical-computer/error-handling/request-processing'
+import { applyErrorMappingFromResponse } from '@practical-computer/error-handling/request-processing'
 
 const response = fetch(...)
 const form = // ...
 
-applyErrorMappingToFormFromUnprocessableEntityResponseResponse(form, response)
+applyErrorMappingFromResponse(form, response)
 ````
 
 #### Loading the Mrujs plugin

--- a/src/plugins/mrujs.js
+++ b/src/plugins/mrujs.js
@@ -1,12 +1,12 @@
-import {applyErrorMappingToFormFromUnprocessableEntityResponseResponse} from '../request-processing.js'
+import {applyErrorMappingFromResponse} from '../request-processing.js'
 
 /**
- * Calls {@link applyErrorMappingToFormFromUnprocessableEntityResponseResponse}, passing along the
+ * Calls {@link applyErrorMappingFromResponse}, passing along the
  * `element` and `response` from the given `event`
  * @param {Event} event - The event that was fired for a fetch response, ideally `ajax:response:error`
  * @param {FormElement} event.detail.element - The `form` event that triggered the event
  * @param {Response} event.detail.response - The `Response` from the fetch request
  */
 export async function unprocessableEntityResponseHandler(event) {
-  await applyErrorMappingToFormFromUnprocessableEntityResponseResponse(event.detail.element, event.detail.response)
+  await applyErrorMappingFromResponse(event.detail.element, event.detail.response)
 }

--- a/src/request-processing.js
+++ b/src/request-processing.js
@@ -6,7 +6,7 @@ import { applyErrorMappingToForm } from './error-mapping.js'
  * @param {FormElement} form - The `form` event that triggered the event
  * @param {Response} response - The `Response` from the fetch request
  */
-export async function applyErrorMappingToFormFromUnprocessableEntityResponseResponse(form, response) {
+export async function applyErrorMappingFromResponse(form, response) {
   if(response.status != 422){ return }
   const errors = await response.json()
   applyErrorMappingToForm(form, errors)

--- a/test/request-processing.test.js
+++ b/test/request-processing.test.js
@@ -43,7 +43,7 @@ suite('Request Processing', async () => {
 
     const response = new Response(JSON.stringify(errors), {status: 400})
 
-    await RequestProcessing.applyErrorMappingToFormFromUnprocessableEntityResponseResponse(form, response)
+    await RequestProcessing.applyErrorMappingFromResponse(form, response)
 
     assert.equal(2, form.querySelectorAll(`[data-error-type]`).length)
   })
@@ -87,7 +87,7 @@ suite('Request Processing', async () => {
 
     const response = new Response(JSON.stringify(errors), {status: 422})
 
-    await RequestProcessing.applyErrorMappingToFormFromUnprocessableEntityResponseResponse(form, response)
+    await RequestProcessing.applyErrorMappingFromResponse(form, response)
 
     assert.equal(1, form.querySelectorAll(`[data-error-type]`).length)
     assert.equal(1, form.querySelectorAll(`[data-error-type][data-error-type="ad_hoc_server_error_1"]`).length)


### PR DESCRIPTION
* Renamed to `applyErrorMappingFromResponse`; the previous method name was simply too long