### PR TITLE
Prefix all `data` attributes with `data-pf-` to unify + avoid collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,18 +79,18 @@ applyErrorMappingButton.addEventListener(`click`, (event) => {
   <custom-error-handling>
     <form id="test-form" aria-describedby='test-form-error-container'>
       <input type="email" id="email-field" aria-describedby="email-field-errors" minlength="4">
-      <section id="email-field-errors" data-error-container>
+      <section id="email-field-errors" data-pf-error-container>
         <ul>
-          <li data-visible data-error-type="error_1">ad-hoc error message 1 <small>(rendered on initial load)</small></li>
-          <li data-preserve data-error-type="tooShort">Custom Preserved Error: Must be at least 4 characters<small>(rendered on initial load)</small></li>
+          <li data-pf-error-visible data-pf-error-type="error_1">ad-hoc error message 1 <small>(rendered on initial load)</small></li>
+          <li data-pf-error-preserve data-pf-error-type="tooShort">Custom Preserved Error: Must be at least 4 characters<small>(rendered on initial load)</small></li>
         </ul>
       </section>
 
-      <section id="test-form-error-container" data-error-container>
+      <section id="test-form-error-container" data-pf-error-container>
         <h2>Form Errors</h2>
         <ul>
-          <li data-visible data-error-type="error_2">ad-hoc error message 2 <small>(rendered on initial load)</small></li>
-          <li data-visible data-preserve data-error-type="error_3">Preserved Error <small>(rendered on initial load)</small></li>
+          <li data-pf-error-visible data-pf-error-type="error_2">ad-hoc error message 2 <small>(rendered on initial load)</small></li>
+          <li data-pf-error-visible data-pf-error-preserve data-pf-error-type="error_3">Preserved Error <small>(rendered on initial load)</small></li>
         </ul>
       </section>
 
@@ -105,7 +105,7 @@ applyErrorMappingButton.addEventListener(`click`, (event) => {
   <textarea id="easy-console" readonly rows=20></textarea>
 
   <template id="pf-error-list-item-template">
-    <li><span>‼️</span> <span data-error-message></span></li>
+    <li><span>‼️</span> <span data-pf-error-message></span></li>
   </template>
 </body>
 ```
@@ -143,18 +143,18 @@ The following terms are used for this package:
 The following data attributes are used by this package:
 
 - Inputs
-  - Validation Event Handling flags.  This package does not provide the validations, but does provide helper functions for checks if an event handler should proceed by checking the value of `data-validation`:
-    - `data-validation="input"`: This input should use `input` validation
-    - `data-validation="change"`: This input should use `change` validation
-    - `data-validation="focusout"`: This input should use `focusout` validation
-    - `data-validation="skip"`: This input should skip any validations
-  - `data-initial-load-errors`: If present, this input has initial load errors, which should not be cleared out when reflecting the constraint validation for the initial load.
-- `data-error-container`: Marks an element as an error container
+  - Validation Event Handling flags.  This package does not provide the validations, but does provide helper functions for checks if an event handler should proceed by checking the value of `data-pf-validation`:
+    - `data-pf-validation="input"`: This input should use `input` validation
+    - `data-pf-validation="change"`: This input should use `change` validation
+    - `data-pf-validation="focusout"`: This input should use `focusout` validation
+    - `data-pf-validation="skip"`: This input should skip any validations
+  - `data-pf-initial-load-errors`: If present, this input has initial load errors, which should not be cleared out when reflecting the constraint validation for the initial load.
+- `data-pf-error-container`: Marks an element as an error container
 - Error list items
-  - `data-visible`: Marks that the error list item should be visible
-  - `data-error-type`: The error type for this list item (eg: `tooShort`, or `some_custom_error_type`)
-  - `data-preserve`: This error list item should not be removed when clearing the error list; useful for rendering custom error messages for default error types. *Just because an error is preserved does not mean it is visible*
-- `data-error-message` Used in the error list item `template` element to indicate where an error message should be rendered in the markup as the `textContent`
+  - `data-pf-error-visible`: Marks that the error list item should be visible
+  - `data-pf-error-type`: The error type for this list item (eg: `tooShort`, or `some_custom_error_type`)
+  - `data-pf-error-preserve`: This error list item should not be removed when clearing the error list; useful for rendering custom error messages for default error types. *Just because an error is preserved does not mean it is visible*
+- `data-pf-error-message` Used in the error list item `template` element to indicate where an error message should be rendered in the markup as the `textContent`
 
 ### Marking an input as invalid
 
@@ -164,20 +164,20 @@ We use `aria-invalid="true"` to indicate that an input is invalid. This makes yo
 
 To link an `input` or `form` to an error container, you:
 
-- Add the error container's markup to the page, with a unique `id` and the `data-error-container` attribute
+- Add the error container's markup to the page, with a unique `id` and the `data-pf-error-container` attribute
 - Include that `id` in the `input`/`form`'s `aria-describedby`
 
-We use the `aria-describedby` so that your markup is **accessible by default**. Since there can be [multiple elements that describe an element](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby#id_reference_list), You specify which one is the error container using `data-error-container`.
+We use the `aria-describedby` so that your markup is **accessible by default**. Since there can be [multiple elements that describe an element](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby#id_reference_list), You specify which one is the error container using `data-pf-error-container`.
 
 #### Example
 ```html
 <form id="test-form" aria-describedby='test-form-error-container'>
   <input type="email" id="email-field" aria-describedby="email-field-errors" minlength="4">
-  <section id="email-field-errors" data-error-container>
+  <section id="email-field-errors" data-pf-error-container>
     <ul></ul>
   </section>
 
-  <section id="test-form-error-container" data-error-container>
+  <section id="test-form-error-container" data-pf-error-container>
     <h2>Form Errors</h2>
     <ul></ul>
   </section>
@@ -215,14 +215,14 @@ if (!window.customElements.get('app-error-handling')) {
 
 ### Handling the initial page load
 
-- Render any error list items that should be visible on the initial page load with the `data-visible` attribute
+- Render any error list items that should be visible on the initial page load with the `data-pf-error-visible` attribute
 - Mark the invalid inputs with:
   - `aria-invalid=true` 
-  - `data-initial-load-errors`
+  - `data-pf-initial-load-errors`
 
 To reflect any other errors that might be present from the Constraint Validation API, you can use the `reflectConstraintValidationForInitialLoad` method in `@practical-computer/error-handling/element-utilities`.
 
-This method will skip any `form.elements` with blank values, or the `data-initial-load-errors` attribute.
+This method will skip any `form.elements` with blank values, or the `data-pf-initial-load-errors` attribute.
 
 
 ### Server-side errors
@@ -294,7 +294,7 @@ One of the best ways to understand this package is to glance at the source. It's
   - Any preserved errors for a list (or for a specific `type` of error)
 - Rendering helper functions, including:
   - Reflecting the current [`ValidityState`](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState) of an element
-  - Applyig the `data-` and ARIA attributes to mark an element as invalid, without going through the Constraint Validation API
+  - Applyig the `data-pf` and ARIA attributes to mark an element as invalid, without going through the Constraint Validation API
   - Marking an error `type` as visible for an element
   - Creating a new error list item element
   - Clearing the error list for an element, or for an entire form.
@@ -323,7 +323,7 @@ Validation is almost always application/framework dependent; and best served by 
 
 #### Markup for rendering errors
 
-You provide the markup, using ARIA attributes, a small set of `data-` attributes, and a `template` element. Fitting error messages into a design is *tough* and extremely context specific. We trust your judgement, and render the text and set the `data-visible` attributes in the places you put us to.
+You provide the markup, using ARIA attributes, a small set of `data-` attributes (prefixed with `data-pf`), and a `template` element. Fitting error messages into a design is *tough* and extremely context specific. We trust your judgement, and render the text and set the `data-pf-error-visible` attributes in the places you put us to.
 
 #### Automatic integrations/hooks/event handlers
 

--- a/css/util.css
+++ b/css/util.css
@@ -1,7 +1,7 @@
-[data-error-container]:not(:has([data-visible])) {
+[data-pf-error-container]:not(:has([data-pf-error-visible])) {
   display: none;
 }
 
-[data-error-container] > ul > li:not([data-visible]) {
+[data-pf-error-container] > ul > li:not([data-pf-error-visible]) {
   display: none;
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -77,7 +77,7 @@
       padding: 1em;
     }
 
-    [data-error-container] {
+    [data-pf-error-container] {
       border: 1px solid red;
     }
   </style>
@@ -90,18 +90,18 @@
   <custom-error-handling>
     <form id="test-form" aria-describedby='test-form-error-container'>
       <input type="email" id="email-field" aria-describedby="email-field-errors" minlength="4">
-      <section id="email-field-errors" data-error-container>
+      <section id="email-field-errors" data-pf-error-container>
         <ul>
-          <li data-visible data-error-type="error_1">ad-hoc error message 1 <small>(rendered on initial load)</small></li>
-          <li data-preserve data-error-type="tooShort">Custom Preserved Error: Must be at least 4 characters<small>(rendered on initial load)</small></li>
+          <li data-pf-error-visible data-pf-error-type="error_1">ad-hoc error message 1 <small>(rendered on initial load)</small></li>
+          <li data-pf-error-preserve data-pf-error-type="tooShort">Custom Preserved Error: Must be at least 4 characters<small>(rendered on initial load)</small></li>
         </ul>
       </section>
 
-      <section id="test-form-error-container" data-error-container>
+      <section id="test-form-error-container" data-pf-error-container>
         <h2>Form Errors</h2>
         <ul>
-          <li data-visible data-error-type="error_2">ad-hoc error message 2 <small>(rendered on initial load)</small></li>
-          <li data-visible data-preserve data-error-type="error_3">Preserved Error <small>(rendered on initial load)</small></li>
+          <li data-pf-error-visible data-pf-error-type="error_2">ad-hoc error message 2 <small>(rendered on initial load)</small></li>
+          <li data-pf-error-visible data-pf-error-preserve data-pf-error-type="error_3">Preserved Error <small>(rendered on initial load)</small></li>
         </ul>
       </section>
 
@@ -116,7 +116,7 @@
   <textarea id="easy-console" readonly rows=20></textarea>
 
   <template id="pf-error-list-item-template">
-    <li><span>‼️</span> <span data-error-message></span></li>
+    <li><span>‼️</span> <span data-pf-error-message></span></li>
   </template>
 </body>
 </html>

--- a/src/element-utilities.js
+++ b/src/element-utilities.js
@@ -11,39 +11,39 @@ export function generateValidationMessage(element) {
 }
 
 /**
- * Checks if the given `element` has `data-validation == "input"`
+ * Checks if the given `element` has `data-pf-validation == "input"`
  * @param {Element} element
- * @return {boolean} Returns true if the element does not have `data-validation == "input"`
+ * @return {boolean} Returns true if the element does not have `data-pf-validation == "input"`
  */
 export function skipInputValidation(element) {
-  return !(element.getAttribute(`data-validation`) === "input")
+  return !(element.getAttribute(`data-pf-validation`) === "input")
 }
 
 /**
- * Checks if the given `element` has `data-validation == "change"`
+ * Checks if the given `element` has `data-pf-validation == "change"`
  * @param {Element} element
- * @return {boolean} Returns true if the element does not have `data-validation == "change"`
+ * @return {boolean} Returns true if the element does not have `data-pf-validation == "change"`
  */
 export function skipChangeValidation(element) {
-  return !(element.getAttribute(`data-validation`) === "change")
+  return !(element.getAttribute(`data-pf-validation`) === "change")
 }
 
 /**
- * Checks if the given `element` has `data-validation == "focusout"`
+ * Checks if the given `element` has `data-pf-validation == "focusout"`
  * @param {Element} element
- * @return {boolean} Returns true if the element does not have `data-validation == "focusout"`
+ * @return {boolean} Returns true if the element does not have `data-pf-validation == "focusout"`
  */
 export function skipFocusoutValidation(element) {
-  return !(element.getAttribute(`data-validation`) === "focusout")
+  return !(element.getAttribute(`data-pf-validation`) === "focusout")
 }
 
 /**
- * Checks if the given `element` given `element` has `data-validation == "skip"`
+ * Checks if the given `element` given `element` has `data-pf-validation == "skip"`
  * @param {Element} element
- * @return {boolean} Returns true if the element has `data-validation == "change"`
+ * @return {boolean} Returns true if the element has `data-pf-validation == "change"`
  */
 export function skipValidation(element) {
-  return (element.getAttribute(`data-validation`) === "skip")
+  return (element.getAttribute(`data-pf-validation`) === "skip")
 }
 
 /**
@@ -74,12 +74,12 @@ export function setValidityStateAttributes(element, isValid) {
 
 /**
  * Used for the initial loading of the given `form`, calls {@link reflectConstraintValidationForElement} for each
- * non-blank item in `form.element` that does not have a `data-initial-load-errors`
+ * non-blank item in `form.element` that does not have a `data-pf-initial-load-errors`
  * @params {FormElement} form the form to reflect the initial Constraint Validation state for
  */
 export function reflectConstraintValidationForInitialLoad(form) {
   for(const element of form.elements) {
-    if(element.hasAttribute(`data-initial-load-errors`)) {
+    if(element.hasAttribute(`data-pf-initial-load-errors`)) {
       continue; // do not change any elements that have server-side errors
     }
     if(element.value !=="" ){

--- a/src/error-containers.js
+++ b/src/error-containers.js
@@ -3,16 +3,16 @@ import { generateValidationMessage } from './element-utilities.js'
 
 /**
  * Returns the ID for the given `element`'s `aria-describedby` attribute of the element that has a
- * `data-error-container` attribute`
+ * `data-pf-error-container` attribute`
  * @param {Element} element
- * @returns {string|undefined} the `aria-describedby` attribute if present and the element has the `data-error-container` attribute`
+ * @returns {string|undefined} the `aria-describedby` attribute if present and the element has the `data-pf-error-container` attribute`
  */
 export function getErrorContainerID(element) {
   const errorContainerID = element.getAttribute(`aria-describedby`)
   if(!errorContainerID || errorContainerID == ''){ return }
 
   return errorContainerID.split(" ").find((x) => {
-    return document.getElementById(x)?.hasAttribute(`data-error-container`)
+    return document.getElementById(x)?.hasAttribute(`data-pf-error-container`)
   })
 }
 
@@ -53,16 +53,16 @@ export function getErrorListFromContainer(container) {
 }
 
 /**
- * Returns the `NodeList` of elements inside the given `errorListElement` with `data-preserve`
+ * Returns the `NodeList` of elements inside the given `errorListElement` with `data-pf-error-preserve`
  * @param {Element} element
- * @returns {NodeList} All elements with the `data-preserve` attribute
+ * @returns {NodeList} All elements with the `data-pf-error-preserve` attribute
  */
 export function getPreservedErrors(errorListElement) {
-  return errorListElement.querySelectorAll(`:scope > [data-preserve]`)
+  return errorListElement.querySelectorAll(`:scope > [data-pf-error-preserve]`)
 }
 
 /**
- * Checks the given `errorListElement` for any preserved errors ({@link getPreservedErrors}) where the `data-error-type`
+ * Checks the given `errorListElement` for any preserved errors ({@link getPreservedErrors}) where the `data-pf-error-type`
  * matches` `type`
  * @params {Element} {@link getErrorList}
  * @params {string} type the error type
@@ -73,7 +73,7 @@ export function hasPreservedErrorForType(errorListElement, type) {
 }
 
 /**
- * Checks the given `errorListElement` for any preserved errors ({@link getPreservedErrors}) where the `data-error-type`
+ * Checks the given `errorListElement` for any preserved errors ({@link getPreservedErrors}) where the `data-pf-error-type`
  * matches` `type` and returns the first match if present
  * @params {Element} {@link getErrorList}
  * @params {string} type the error type
@@ -81,27 +81,27 @@ export function hasPreservedErrorForType(errorListElement, type) {
  */
 export function getPreservedErrorForType(errorListElement, type) {
   return [...getPreservedErrors(errorListElement)].find((x) => {
-    return x.getAttribute(`data-error-type`)?.toString() == type.toString()
+    return x.getAttribute(`data-pf-error-type`)?.toString() == type.toString()
   })
 }
 
 /**
- * Marks the given element as a preserved error message, with the `data-preserve` attribute
+ * Marks the given element as a preserved error message, with the `data-pf-error-preserve` attribute
  * @params {Element} element the error element to mark as preserved
  */
 export function markAsPreservedError(element) {
-  element.setAttribute(`data-preserve`, true)
+  element.setAttribute(`data-pf-error-preserve`, true)
 }
 
 /**
- * Returns the `element` that has the given `data-error-type` if it's present.
+ * Returns the `element` that has the given `data-pf-error-type` if it's present.
  * @params {Element} {@link getErrorList}
  * @params {string} type the error type
  * @returns {Element|null}
  */
 export function getErrorForType(errorListElement, type) {
-  return [...errorListElement.querySelectorAll(`[data-error-type]`)].find((x) => {
-    return x.getAttribute(`data-error-type`)?.toString() == type.toString()
+  return [...errorListElement.querySelectorAll(`[data-pf-error-type]`)].find((x) => {
+    return x.getAttribute(`data-pf-error-type`)?.toString() == type.toString()
   })
 }
 

--- a/src/error-mapping.js
+++ b/src/error-mapping.js
@@ -30,7 +30,7 @@ import {
  * @param {string} errors[].container_id - The ID of the container this error message should be rendered in
  * @param {string} errors[].element_id - The ID of the element to call {@link setValidityStateAttributes} with `false` for
  * @param {string} errors[].message - the error message
- * @param {string} errors[].type - the value for `data-error-type` that represents the type of error this is
+ * @param {string} errors[].type - the value for `data-pf-error-type` that represents the type of error this is
  *
  * @example
  * // For example, a JSON response from a fetch request

--- a/src/event-handlers.js
+++ b/src/event-handlers.js
@@ -35,7 +35,7 @@ export function validateFormSubmitEventHandler(event) {
 
 /**
  * Calls {@link reflectConstraintValidationForElement} if the `event.target` has
- * `data-validation="input"` and does not have `data-skip-validation`
+ * `data-pf-validation="input"`
  *
  * @param {Event} event
  */
@@ -48,7 +48,7 @@ export function inputValidationEventHandler(event) {
 
 /**
  * Calls {@link reflectConstraintValidationForElement} if the `event.target` has
- * `data-validation="focusout"` and does not have `data-skip-validation`
+ * `data-pf-validation="focusout"`
  * @param {Event} event
  */
 export function focusoutValidationEventHandler(event) {

--- a/src/fieldset/rendering.js
+++ b/src/fieldset/rendering.js
@@ -28,7 +28,7 @@ export function clearErrorListForFieldset(fieldset) {
  * Renders the given custom message + type pair for the given fieldset
  * calls {@link clearErrorList } for the given `fieldset`
  *
- * replaces the error list to include that message (marked as `data-visible`) and any `preserved` errors
+ * replaces the error list to include that message (marked as `data-pf-error-visible`) and any `preserved` errors
  *
  * @param {FieldsetElement} fieldset
  */

--- a/src/rendering.js
+++ b/src/rendering.js
@@ -14,7 +14,7 @@ import {
  *
  * calls {@link clearErrorList }.
  * calls {@link renderErrorMessageListItem} for the {@link generateValidationMessage} and replaces the
- * error list to include that message (marked as `data-visible`) and any `preserved` errors
+ * error list to include that message (marked as `data-pf-error-visible`) and any `preserved` errors
  *
  * @param {Element} element
  */
@@ -45,41 +45,41 @@ export function renderConstraintValidationMessageForElement(element) {
 
 /**
  * Checks the given `errorListElement` for an error of the given `type`. If it's present,
- * It marks it with the `data-visible` attribute`
+ * It marks it with the `data-pf-error-visible` attribute`
  * @params {Element} {@link getErrorList}
  * @params {string} type the error type
  */
 export function markErrorTypeAsVisible(errorListElement, type) {
-  getErrorForType(errorListElement, type)?.toggleAttribute(`data-visible`, true)
+  getErrorForType(errorListElement, type)?.toggleAttribute(`data-pf-error-visible`, true)
 }
 
 /**
- * Clones the {@link errorListItemTemplate}, setting the textContent of the element with `[data-error-message]` to the message,
- * and setting the `data-error-type` to the given type.
+ * Clones the {@link errorListItemTemplate}, setting the textContent of the element with `[data-pf-error-message]` to the message,
+ * and setting the `data-pf-error-type` to the given type.
  *
  * @params {string} message the error message
- * @params {string} type the value that will be used for `data-error-type``
+ * @params {string} type the value that will be used for `data-pf-error-type``
  * @returns {Element} the cloned element
  */
 export function errorMessageListItem(message, type) {
   const clone = errorListItemTemplate().content.cloneNode(true).querySelector(`*:first-child`)
 
-  clone.setAttribute(`data-error-type`, type)
-  clone.querySelector(`[data-error-message]`).textContent = message
+  clone.setAttribute(`data-pf-error-type`, type)
+  clone.querySelector(`[data-pf-error-message]`).textContent = message
 
   return clone
 }
 
 /**
  * Clears the error messages from the list, while keeping preserved errors.
- * Removes the `data-visible` attribute from any preserved attributes
+ * Removes the `data-pf-error-visible` attribute from any preserved attributes
  * @param {Element} element
  */
 export function clearErrorList(errorListElement) {
   const preservedErrors = [...getPreservedErrors(errorListElement)]
 
   preservedErrors.forEach((x) => {
-    x.removeAttribute(`data-visible`)
+    x.removeAttribute(`data-pf-error-visible`)
   })
 
   errorListElement.replaceChildren(...preservedErrors)

--- a/test/element-utilities.test.js
+++ b/test/element-utilities.test.js
@@ -23,48 +23,48 @@ suite('Element Utilities', async () => {
 
   test(`skipInputValidation`, async() => {
     const el = await fixture(html`
-      <input type="text" data-validation="input">
+      <input type="text" data-pf-validation="input">
     `);
 
     assert.equal(false, ElementUtils.skipInputValidation(el))
 
-    el.setAttribute(`data-validation`, `change`)
+    el.setAttribute(`data-pf-validation`, `change`)
 
     assert.equal(true, ElementUtils.skipInputValidation(el))
   })
 
   test(`skipChangeValidation`, async() => {
     const el = await fixture(html`
-      <input type="text" data-validation="change">
+      <input type="text" data-pf-validation="change">
     `);
 
     assert.equal(false, ElementUtils.skipChangeValidation(el))
 
-    el.setAttribute(`data-validation`, `input`)
+    el.setAttribute(`data-pf-validation`, `input`)
 
     assert.equal(true, ElementUtils.skipChangeValidation(el))
   })
 
   test(`skipFocusoutValidation`, async() => {
     const el = await fixture(html`
-      <input type="text" data-validation="focusout">
+      <input type="text" data-pf-validation="focusout">
     `);
 
     assert.equal(false, ElementUtils.skipFocusoutValidation(el))
 
-    el.setAttribute(`data-validation`, `input`)
+    el.setAttribute(`data-pf-validation`, `input`)
 
     assert.equal(true, ElementUtils.skipFocusoutValidation(el))
   })
 
   test(`skipValidation`, async() => {
     const el = await fixture(html`
-      <input type="text" data-validation="skip">
+      <input type="text" data-pf-validation="skip">
     `);
 
     assert.equal(true, ElementUtils.skipValidation(el))
 
-    el.setAttribute(`data-validation`, `input`)
+    el.setAttribute(`data-pf-validation`, `input`)
 
     assert.equal(false, ElementUtils.skipValidation(el))
   })
@@ -99,15 +99,15 @@ suite('Element Utilities', async () => {
     const container = await fixture(html`
       <div>
         <input type="text" id="name-field" aria-describedby="name-field-errors" required>
-        <section id="name-field-errors" data-error-container>
+        <section id="name-field-errors" data-pf-error-container>
           <ul>
-            <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-            <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+            <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+            <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
           </ul>
         </section>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `);
@@ -122,7 +122,7 @@ suite('Element Utilities', async () => {
 
     assert.equal(1, document.querySelectorAll(`#name-field-errors li`).length)
 
-    const errorElement = document.querySelector(`#name-field-errors li[data-visible][data-error-type="valueMissing"]`)
+    const errorElement = document.querySelector(`#name-field-errors li[data-pf-error-visible][data-pf-error-type="valueMissing"]`)
 
     assert.isNotNull(errorElement)
     assert.equal("‼️ Please fill out this field.", errorElement.textContent)
@@ -142,15 +142,15 @@ suite('Element Utilities', async () => {
     const container = await fixture(html`
       <div>
         <input type="text" id="name-field" aria-describedby="name-field-errors">
-        <section id="name-field-errors" data-error-container>
+        <section id="name-field-errors" data-pf-error-container>
           <ul>
-            <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-            <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+            <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+            <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
           </ul>
         </section>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `);
@@ -169,73 +169,73 @@ suite('Element Utilities', async () => {
       <form aria-describedby="fallback-error-section">
         <section>
           <input type="number" id="count-field" aria-describedby="count-field-errors" value="10" max="5">
-            <section id="count-field-errors" data-error-container>
+            <section id="count-field-errors" data-pf-error-container>
               <ul>
-                <li data-preserve data-error-type="valueMissing">The preserved message</li>
-                <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+                <li data-pf-error-preserve data-pf-error-type="valueMissing">The preserved message</li>
+                <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
               </ul>
             </section>
         </section>
 
         <section>
           <input type="text" id="title-field" aria-describedby="title-field-errors" required value="Server invalid">
-            <section id="title-field-errors" data-error-container>
+            <section id="title-field-errors" data-pf-error-container>
               <ul>
-                <li data-visible data-preserve data-error-type="already_taken">The preserved message</li>
-                <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+                <li data-pf-error-visible data-pf-error-preserve data-pf-error-type="already_taken">The preserved message</li>
+                <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
               </ul>
             </section>
         </section>
 
         <section>
-          <input type="email" id="email-field" aria-describedby="email-field-errors" data-initial-load-errors>
-            <section id="email-field-errors" data-error-container>
+          <input type="email" id="email-field" aria-describedby="email-field-errors" data-pf-initial-load-errors>
+            <section id="email-field-errors" data-pf-error-container>
               <ul>
-                <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-                <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+                <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+                <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
               </ul>
             </section>
         </section>
 
         <section>
-          <input type="number" id="confirm-count-field" aria-describedby="confirm-count-field-errors" value="10" max="5" data-initial-load-errors>
-            <section id="confirm-count-field-errors" data-error-container>
+          <input type="number" id="confirm-count-field" aria-describedby="confirm-count-field-errors" value="10" max="5" data-pf-initial-load-errors>
+            <section id="confirm-count-field-errors" data-pf-error-container>
               <ul>
-                <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-                <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+                <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+                <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
               </ul>
             </section>
         </section>
 
-        <section id="fallback-error-section" data-error-container>
+        <section id="fallback-error-section" data-pf-error-container>
           <ul>
-            <li data-visible data-error-type="error_1">An ad-hoc fallback error 1</li>
-            <li data-visible data-error-type="custom_1" data-preserve>Preserved fallback error</li>
+            <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc fallback error 1</li>
+            <li data-pf-error-visible data-pf-error-type="custom_1" data-pf-error-preserve>Preserved fallback error</li>
           </ul>
         </section>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </form>
     `)
 
-    assert.equal(2, document.querySelectorAll(`#count-field-errors [data-error-type]`).length)
-    assert.equal(2, document.querySelectorAll(`#title-field-errors [data-error-type]`).length)
-    assert.equal(2, document.querySelectorAll(`#email-field-errors [data-error-type]`).length)
-    assert.equal(2, document.querySelectorAll(`#confirm-count-field-errors [data-error-type]`).length)
-    assert.equal(2, document.querySelectorAll(`#fallback-error-section [data-error-type]`).length)
+    assert.equal(2, document.querySelectorAll(`#count-field-errors [data-pf-error-type]`).length)
+    assert.equal(2, document.querySelectorAll(`#title-field-errors [data-pf-error-type]`).length)
+    assert.equal(2, document.querySelectorAll(`#email-field-errors [data-pf-error-type]`).length)
+    assert.equal(2, document.querySelectorAll(`#confirm-count-field-errors [data-pf-error-type]`).length)
+    assert.equal(2, document.querySelectorAll(`#fallback-error-section [data-pf-error-type]`).length)
 
     ElementUtils.reflectConstraintValidationForInitialLoad(form)
 
-    assert.equal(2, document.querySelectorAll(`#count-field-errors [data-error-type]`).length)
-    assert.equal(1, document.querySelectorAll(`#title-field-errors [data-error-type]`).length)
-    assert.equal(2, document.querySelectorAll(`#email-field-errors [data-error-type]`).length)
-    assert.equal(2, document.querySelectorAll(`#confirm-count-field-errors [data-error-type]`).length)
-    assert.equal(2, document.querySelectorAll(`#fallback-error-section [data-error-type]`).length)
+    assert.equal(2, document.querySelectorAll(`#count-field-errors [data-pf-error-type]`).length)
+    assert.equal(1, document.querySelectorAll(`#title-field-errors [data-pf-error-type]`).length)
+    assert.equal(2, document.querySelectorAll(`#email-field-errors [data-pf-error-type]`).length)
+    assert.equal(2, document.querySelectorAll(`#confirm-count-field-errors [data-pf-error-type]`).length)
+    assert.equal(2, document.querySelectorAll(`#fallback-error-section [data-pf-error-type]`).length)
 
-    assert.equal(1, document.querySelectorAll(`#title-field-errors [data-error-type="already_taken"]`).length)
+    assert.equal(1, document.querySelectorAll(`#title-field-errors [data-pf-error-type="already_taken"]`).length)
 
-    assert.equal(1, document.querySelectorAll(`#count-field-errors [data-visible][data-error-type="rangeOverflow"]`).length)
+    assert.equal(1, document.querySelectorAll(`#count-field-errors [data-pf-error-visible][data-pf-error-type="rangeOverflow"]`).length)
   })
 })

--- a/test/error-containers.test.js
+++ b/test/error-containers.test.js
@@ -22,7 +22,7 @@ suite('Error Container Utilities', async () => {
     }, TypeError)
 
     const errorContainer = await fixture(html`
-       <section id="name-field-errors" data-error-container>
+       <section id="name-field-errors" data-pf-error-container>
        </section>
     `)
 
@@ -49,7 +49,7 @@ suite('Error Container Utilities', async () => {
 
     const error_2 = document.createElement(`li`)
     error_2.textContent = "error 1"
-    error_2.setAttribute(`data-preserve`, true)
+    error_2.setAttribute(`data-pf-error-preserve`, true)
     errorList.append(error_2)
 
     assert.equal(1, ErrorContainerUtils.getPreservedErrors(errorList).length)
@@ -70,7 +70,7 @@ suite('Error Container Utilities', async () => {
         <p>Some content</p>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span><span data-error-message></span></li>
+          <li><span>‼️</span><span data-pf-error-message></span></li>
         </template>
       </div>
     `)
@@ -79,17 +79,17 @@ suite('Error Container Utilities', async () => {
     assert.isNotNull(templateElement)
 
     const clone = templateElement.content.cloneNode(true).querySelector(`*:first-child`)
-    assert.equal(1, clone.querySelectorAll(`[data-error-message]`).length)
+    assert.equal(1, clone.querySelectorAll(`[data-pf-error-message]`).length)
   })
 
   test(`hasPreservedErrorForType/getPreservedErrorForType`, async() => {
     const errorList = await fixture(html`
       <ul>
-        <li data-visible data-error-type="error_1">An ad-hoc error 1</li>
-        <li data-visible data-error-type="error_2">An ad-hoc error 2</li>
-        <li data-visible data-error-type="custom_1" data-preserve>Preserved error 1</li>
-        <li data-error-type="custom_2" data-preserve>Preserved error 2</li>
-        <li data-preserve>Error without type</li>
+        <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error 1</li>
+        <li data-pf-error-visible data-pf-error-type="error_2">An ad-hoc error 2</li>
+        <li data-pf-error-visible data-pf-error-type="custom_1" data-pf-error-preserve>Preserved error 1</li>
+        <li data-pf-error-type="custom_2" data-pf-error-preserve>Preserved error 2</li>
+        <li data-pf-error-preserve>Error without type</li>
       </ul>
     `)
 
@@ -106,11 +106,11 @@ suite('Error Container Utilities', async () => {
   test(`getErrorForType`, async() => {
     const errorList = await fixture(html`
       <ul>
-        <li data-visible data-error-type="error_1">An ad-hoc error 1</li>
-        <li data-visible data-error-type="error_2">An ad-hoc error 2</li>
-        <li data-visible data-error-type="custom_1" data-preserve>Preserved error 1</li>
-        <li data-error-type="custom_2" data-preserve>Preserved error 3</li>
-        <li data-preserve>Error without type</li>
+        <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error 1</li>
+        <li data-pf-error-visible data-pf-error-type="error_2">An ad-hoc error 2</li>
+        <li data-pf-error-visible data-pf-error-type="custom_1" data-pf-error-preserve>Preserved error 1</li>
+        <li data-pf-error-type="custom_2" data-pf-error-preserve>Preserved error 3</li>
+        <li data-pf-error-preserve>Error without type</li>
       </ul>
     `)
 
@@ -122,14 +122,14 @@ suite('Error Container Utilities', async () => {
   test(`markAsPreservedError`, async () => {
     const errorList = await fixture(html`
       <ul>
-        <li data-visible data-error-type="error_1">An ad-hoc error 1</li>
-        <li data-visible data-error-type="error_2">Error to mark as preserved</li>
+        <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error 1</li>
+        <li data-pf-error-visible data-pf-error-type="error_2">Error to mark as preserved</li>
       </ul>
     `)
 
     assert.equal(false, ErrorContainerUtils.hasPreservedErrorForType(errorList, `error_2`))
 
-    ErrorContainerUtils.markAsPreservedError(errorList.querySelector(`[data-error-type="error_2"]`))
+    ErrorContainerUtils.markAsPreservedError(errorList.querySelector(`[data-pf-error-type="error_2"]`))
 
     assert.equal(true, ErrorContainerUtils.hasPreservedErrorForType(errorList, `error_2`))
   })

--- a/test/error-handling-element.test.js
+++ b/test/error-handling-element.test.js
@@ -19,22 +19,22 @@ suite('ErrorHandlingElement', async () => {
         <custom-error-handling>
           <form id="test-form" aria-describedby='test-form-error-container'>
             <input type="email" id="email-field" aria-describedby="email-field-errors">
-            <section id="email-field-errors" data-error-container>
+            <section id="email-field-errors" data-pf-error-container>
               <ul>
-                <li data-visible data-error-type="error_1">ad-hoc error message 1</li>
+                <li data-pf-error-visible data-pf-error-type="error_1">ad-hoc error message 1</li>
               </ul>
             </section>
 
-            <section id="test-form-error-container" data-error-container>
+            <section id="test-form-error-container" data-pf-error-container>
               <ul>
-                <li data-visible data-error-type="error_2">ad-hoc error message 2</li>
+                <li data-pf-error-visible data-pf-error-type="error_2">ad-hoc error message 2</li>
               </ul>
             </section>
           </form>
         </custom-error-handling>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `)

--- a/test/error-mapping.test.js
+++ b/test/error-mapping.test.js
@@ -9,17 +9,17 @@ suite('Error Mapping', async () => {
       <div>
         <form id="test-form" aria-describedby='test-form-error-container'>
           <input type="email" id="email-field" aria-describedby="email-field-errors">
-          <section id="email-field-errors" data-error-container>
+          <section id="email-field-errors" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_1">ad-hoc error message 1</li>
+              <li data-pf-error-visible data-pf-error-type="error_1">ad-hoc error message 1</li>
             </ul>
           </section>
 
           <input type="email" id="confirm-email-field" aria-describedby="confirm-email-field-errors">
-          <section id="confirm-email-field-errors" data-error-container>
+          <section id="confirm-email-field-errors" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_1">ad-hoc error message 1</li>
-              <li data-visible data-preserve data-error-type="unconfirmed_error">Unconfirmed error</li>
+              <li data-pf-error-visible data-pf-error-type="error_1">ad-hoc error message 1</li>
+              <li data-pf-error-visible data-pf-error-preserve data-pf-error-type="unconfirmed_error">Unconfirmed error</li>
             </ul>
           </section>
 
@@ -28,9 +28,9 @@ suite('Error Mapping', async () => {
           <input type="text" id="username-field">
 
           <textarea id="comments-field" aria-describedby="comments-field-errors" required></textarea>
-          <section id="comments-field-errors" data-error-container>
+          <section id="comments-field-errors" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_1">ad-hoc error message 1</li>
+              <li data-pf-error-visible data-pf-error-type="error_1">ad-hoc error message 1</li>
             </ul>
           </section>
 
@@ -38,20 +38,20 @@ suite('Error Mapping', async () => {
             A custom rich text editor
           </rich-text-editor>
 
-          <section id="rich-text-editor-error-container" data-error-container>
+          <section id="rich-text-editor-error-container" data-pf-error-container>
             <ul></ul>
           </section>
 
-          <section id="test-form-error-container" data-error-container>
+          <section id="test-form-error-container" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_2">ad-hoc error message 2</li>
-              <li data-visible data-error-type="preserve_error_1" data-preserve>Preserved message</li>
-              <li data-error-type="preserve_error_2" data-preserve>Preserved message</li>
+              <li data-pf-error-visible data-pf-error-type="error_2">ad-hoc error message 2</li>
+              <li data-pf-error-visible data-pf-error-type="preserve_error_1" data-pf-error-preserve>Preserved message</li>
+              <li data-pf-error-type="preserve_error_2" data-pf-error-preserve>Preserved message</li>
             </ul>
           </section>
         </form>
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
 
       </div>
@@ -112,48 +112,48 @@ suite('Error Mapping', async () => {
 
     ErrorMapping.applyErrorMappingToForm(form, errors)
 
-    assert.equal(4, document.getElementById(`test-form-error-container`).querySelectorAll(`[data-error-type][data-visible]`).length)
+    assert.equal(4, document.getElementById(`test-form-error-container`).querySelectorAll(`[data-pf-error-type][data-pf-error-visible]`).length)
     assert.equal(
       "‼️ Ad-hoc server error 1",
-      document.getElementById(`test-form-error-container`).querySelector(`[data-visible][data-error-type="ad_hoc_server_error_1"]`).textContent
+      document.getElementById(`test-form-error-container`).querySelector(`[data-pf-error-visible][data-pf-error-type="ad_hoc_server_error_1"]`).textContent
     )
 
     assert.equal(
       "‼️ New Content for preserved message",
-      document.getElementById(`test-form-error-container`).querySelector(`[data-visible][data-error-type="preserve_error_2"]`).textContent
+      document.getElementById(`test-form-error-container`).querySelector(`[data-pf-error-visible][data-pf-error-type="preserve_error_2"]`).textContent
     )
 
     assert.equal(
       "‼️ Ad-hoc server error 2",
-      document.getElementById(`test-form-error-container`).querySelector(`[data-visible][data-error-type="ad_hoc_server_error_2"]`).textContent
+      document.getElementById(`test-form-error-container`).querySelector(`[data-pf-error-visible][data-pf-error-type="ad_hoc_server_error_2"]`).textContent
     )
 
     assert.equal(
       "‼️ Ad-hoc server error 3",
-      document.getElementById(`test-form-error-container`).querySelector(`[data-visible][data-error-type="ad_hoc_server_error_3"]`).textContent
+      document.getElementById(`test-form-error-container`).querySelector(`[data-pf-error-visible][data-pf-error-type="ad_hoc_server_error_3"]`).textContent
     )
 
-    assert.equal(1, document.getElementById(`rich-text-editor-error-container`).querySelectorAll(`[data-error-type][data-visible]`).length)
+    assert.equal(1, document.getElementById(`rich-text-editor-error-container`).querySelectorAll(`[data-pf-error-type][data-pf-error-visible]`).length)
     assert.equal(
       "‼️ Ad-hoc server error 4",
-      document.getElementById(`rich-text-editor-error-container`).querySelector(`[data-visible][data-error-type="ad_hoc_server_error_4"]`).textContent
+      document.getElementById(`rich-text-editor-error-container`).querySelector(`[data-pf-error-visible][data-pf-error-type="ad_hoc_server_error_4"]`).textContent
     )
 
-    assert.equal(1, document.getElementById(`email-field-errors`).querySelectorAll(`[data-error-type][data-visible]`).length)
+    assert.equal(1, document.getElementById(`email-field-errors`).querySelectorAll(`[data-pf-error-type][data-pf-error-visible]`).length)
     assert.equal(
       "‼️ Ad-hoc server error 5",
-      document.getElementById(`email-field-errors`).querySelector(`[data-visible][data-error-type="ad_hoc_server_error_5"]`).textContent
+      document.getElementById(`email-field-errors`).querySelector(`[data-pf-error-visible][data-pf-error-type="ad_hoc_server_error_5"]`).textContent
     )
 
-    assert.equal(2, document.getElementById(`confirm-email-field-errors`).querySelectorAll(`[data-error-type][data-visible]`).length)
+    assert.equal(2, document.getElementById(`confirm-email-field-errors`).querySelectorAll(`[data-pf-error-type][data-pf-error-visible]`).length)
     assert.equal(
       "‼️ Ad-hoc server error 6",
-      document.getElementById(`confirm-email-field-errors`).querySelector(`[data-visible][data-error-type="ad_hoc_server_error_6"]`).textContent
+      document.getElementById(`confirm-email-field-errors`).querySelector(`[data-pf-error-visible][data-pf-error-type="ad_hoc_server_error_6"]`).textContent
     )
 
     assert.equal(
       "‼️ Please confirm",
-      document.getElementById(`confirm-email-field-errors`).querySelector(`[data-visible][data-error-type="unconfirmed_error"]`).textContent
+      document.getElementById(`confirm-email-field-errors`).querySelector(`[data-pf-error-visible][data-pf-error-type="unconfirmed_error"]`).textContent
     )
   })
 })

--- a/test/event-handlers.test.js
+++ b/test/event-handlers.test.js
@@ -3,7 +3,7 @@ import { html, fixture, assert } from '@open-wc/testing';
 import * as EventHandlers from '@practical-computer/error-handling/event-handlers';
 
 suite('Event Handlers', async () => {
-  test(`inputValidationEventHandler: does nothing if no data-validation`, async() => {
+  test(`inputValidationEventHandler: does nothing if no data-pf-validation`, async() => {
     const input = await fixture(html`
       <input type="email" required>
     `)
@@ -15,9 +15,9 @@ suite('Event Handlers', async () => {
     assert.equal(false, input.hasAttribute(`aria-invalid`))
   })
 
-  test(`inputValidationEventHandler: fires if data-validation="input"`, async() => {
+  test(`inputValidationEventHandler: fires if data-pf-validation="input"`, async() => {
     const input = await fixture(html`
-      <input type="email" required data-validation="input">
+      <input type="email" required data-pf-validation="input">
     `)
 
     input.addEventListener(`test-event`, EventHandlers.inputValidationEventHandler)
@@ -27,9 +27,9 @@ suite('Event Handlers', async () => {
     assert.equal("true", input.getAttribute(`aria-invalid`))
   })
 
-  test(`inputValidationEventHandler: does nothing if data-validation="skip"`, async() => {
+  test(`inputValidationEventHandler: does nothing if data-pf-validation="skip"`, async() => {
     const input = await fixture(html`
-      <input type="email" required data-validation="skip">
+      <input type="email" required data-pf-validation="skip">
     `)
 
     input.addEventListener(`test-event`, EventHandlers.inputValidationEventHandler)
@@ -39,7 +39,7 @@ suite('Event Handlers', async () => {
     assert.equal(false, input.hasAttribute(`aria-invalid`))
   })
 
-  test(`focusoutValidationEventHandler: does nothing if no data-validation="input"`, async() => {
+  test(`focusoutValidationEventHandler: does nothing if no data-pf-validation="input"`, async() => {
     const input = await fixture(html`
       <input type="email" required>
     `)
@@ -51,9 +51,9 @@ suite('Event Handlers', async () => {
     assert.equal(false, input.hasAttribute(`aria-invalid`))
   })
 
-  test(`focusoutValidationEventHandler: fires if data-validation="focusout"`, async() => {
+  test(`focusoutValidationEventHandler: fires if data-pf-validation="focusout"`, async() => {
     const input = await fixture(html`
-      <input type="email" required data-validation="focusout">
+      <input type="email" required data-pf-validation="focusout">
     `)
 
     input.addEventListener(`test-event`, EventHandlers.focusoutValidationEventHandler)
@@ -63,9 +63,9 @@ suite('Event Handlers', async () => {
     assert.equal("true", input.getAttribute(`aria-invalid`))
   })
 
-  test(`focusoutValidationEventHandler: does nothing if data-validation="skip"`, async() => {
+  test(`focusoutValidationEventHandler: does nothing if data-pf-validation="skip"`, async() => {
     const input = await fixture(html`
-      <input type="email" required data-validation="skip">
+      <input type="email" required data-pf-validation="skip">
     `)
 
     input.addEventListener(`test-event`, EventHandlers.focusoutValidationEventHandler)

--- a/test/fieldset/fieldset-validation-element.test.js
+++ b/test/fieldset/fieldset-validation-element.test.js
@@ -32,17 +32,17 @@ suite('ErrorHandlingElement', async () => {
               <input type="checkbox" name="service" required>
             </custom-fieldset-validation>
 
-            <section id="terms-fieldset-errors" data-error-container>
+            <section id="terms-fieldset-errors" data-pf-error-container>
               <ul>
-                <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-                <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+                <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+                <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
               </ul>
             </section>
           </fieldset>
         </form>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `)

--- a/test/fieldset/minimum-field-values-fieldset-validation-element.test.js
+++ b/test/fieldset/minimum-field-values-fieldset-validation-element.test.js
@@ -51,24 +51,24 @@ suite('minimum-field-values-fieldset-validation-element', async () => {
               fieldset="terms-fieldset"
               field-name="terms"
               error-container-aria="terms-fieldset-errors-aria"
-              data-validation="change"
+              data-pf-validation="change"
             >
               <input type="checkbox" name="terms" id="privacy" value="privacy" required>
               <input type="checkbox" name="terms" id="service" value="service" required>
               <input type="checkbox" name="terms" id="data" value="data" required>
             </minimum-field-values-fieldset-validation>
 
-            <section id="terms-fieldset-errors" data-error-container>
+            <section id="terms-fieldset-errors" data-pf-error-container>
               <ul>
-                <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-                <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+                <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+                <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
               </ul>
             </section>
           </fieldset>
         </form>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `)
@@ -89,7 +89,7 @@ suite('minimum-field-values-fieldset-validation-element', async () => {
     privacy.checked = true
     privacy.dispatchEvent(new Event(`change`, {bubbles: true}))
 
-    const errorElement = document.querySelector(`#terms-fieldset-errors li[data-visible][data-error-type="tooShort"]`)
+    const errorElement = document.querySelector(`#terms-fieldset-errors li[data-pf-error-visible][data-pf-error-type="tooShort"]`)
 
     assert.isNotNull(errorElement)
     assert.equal("‼️ Please choose 2 terms", errorElement.textContent)
@@ -121,7 +121,7 @@ suite('minimum-field-values-fieldset-validation-element', async () => {
               fieldset="terms-fieldset"
               field-name="terms"
               error-container-aria="terms-fieldset-errors-aria"
-              data-validation="focusout"
+              data-pf-validation="focusout"
             >
               <input type="checkbox" name="terms" id="privacy" value="privacy" required>
               <input type="checkbox" name="terms" id="service" value="service" required>
@@ -130,17 +130,17 @@ suite('minimum-field-values-fieldset-validation-element', async () => {
 
             <button>Other focusable element</button>
 
-            <section id="terms-fieldset-errors" data-error-container>
+            <section id="terms-fieldset-errors" data-pf-error-container>
               <ul>
-                <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-                <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+                <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+                <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
               </ul>
             </section>
           </fieldset>
         </form>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `)
@@ -162,7 +162,7 @@ suite('minimum-field-values-fieldset-validation-element', async () => {
     privacy.checked = true
     privacy.dispatchEvent(new FocusEvent(`focusout`, {bubbles: true, relatedTarget: button}))
 
-    const errorElement = document.querySelector(`#terms-fieldset-errors li[data-visible][data-error-type="tooShort"]`)
+    const errorElement = document.querySelector(`#terms-fieldset-errors li[data-pf-error-visible][data-pf-error-type="tooShort"]`)
 
     assert.isNotNull(errorElement)
     assert.equal("‼️ Please choose 2 terms", errorElement.textContent)
@@ -200,17 +200,17 @@ suite('minimum-field-values-fieldset-validation-element', async () => {
               <input type="checkbox" name="terms" id="data" value="data">
             </minimum-field-values-fieldset-validation>
 
-            <section id="terms-fieldset-errors" data-error-container>
+            <section id="terms-fieldset-errors" data-pf-error-container>
               <ul>
-                <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-                <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+                <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+                <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
               </ul>
             </section>
           </fieldset>
         </form>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `)
@@ -225,7 +225,7 @@ suite('minimum-field-values-fieldset-validation-element', async () => {
     await new Promise((resolve) => {
       const handler = (event) => {
         event.preventDefault()
-        const errorElement = document.querySelector(`#terms-fieldset-errors li[data-visible][data-error-type="tooShort"]`)
+        const errorElement = document.querySelector(`#terms-fieldset-errors li[data-pf-error-visible][data-pf-error-type="tooShort"]`)
 
         assert.isNotNull(errorElement)
         assert.equal("‼️ Please choose 2 terms", errorElement.textContent)
@@ -245,7 +245,7 @@ suite('minimum-field-values-fieldset-validation-element', async () => {
     await new Promise((resolve) => {
       form.addEventListener(`submit`, (event) => {
         event.preventDefault()
-        const errorElement = document.querySelector(`#terms-fieldset-errors li[data-visible][data-error-type="tooShort"]`)
+        const errorElement = document.querySelector(`#terms-fieldset-errors li[data-pf-error-visible][data-pf-error-type="tooShort"]`)
 
         assert.isNull(errorElement)
 

--- a/test/fieldset/rendering.test.js
+++ b/test/fieldset/rendering.test.js
@@ -10,16 +10,16 @@ suite('Fieldset Rendering', async () => {
           <input type="checkbox" name="privacy" required>
           <input type="checkbox" name="service" required>
 
-          <section id="terms-fieldset-errors" data-error-container>
+          <section id="terms-fieldset-errors" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-              <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+              <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+              <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
             </ul>
           </section>
         </fieldset>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `);
@@ -33,24 +33,24 @@ suite('Fieldset Rendering', async () => {
     assert.equal(0, document.querySelectorAll(`#terms-fieldset-errors li`).length)
   })
 
-  test(`clearErrorListForFieldset: keeps the given preserved message, removing the data-visible attribute`, async () => {
+  test(`clearErrorListForFieldset: keeps the given preserved message, removing the data-pf-error-visible attribute`, async () => {
     const container = await fixture(html`
       <div>
         <fieldset aria-describedby="terms-fieldset-errors">
           <input type="checkbox" name="privacy" required>
           <input type="checkbox" name="service" required>
 
-          <section id="terms-fieldset-errors" data-error-container>
+          <section id="terms-fieldset-errors" data-pf-error-container>
             <ul>
-              <li data-preserve data-error-type="required">The preserved message</li>
-              <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-              <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+              <li data-pf-error-preserve data-pf-error-type="required">The preserved message</li>
+              <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+              <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
             </ul>
           </section>
         </fieldset>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `);
@@ -63,10 +63,10 @@ suite('Fieldset Rendering', async () => {
 
     assert.equal(1, document.querySelectorAll(`#terms-fieldset-errors li`).length)
 
-    const errorElement = document.querySelector(`#terms-fieldset-errors li[data-error-type="required"]`)
+    const errorElement = document.querySelector(`#terms-fieldset-errors li[data-pf-error-type="required"]`)
 
-    assert.equal(false, errorElement.hasAttribute(`data-visible`))
-    assert.equal(true, errorElement.hasAttribute(`data-preserve`))
+    assert.equal(false, errorElement.hasAttribute(`data-pf-error-visible`))
+    assert.equal(true, errorElement.hasAttribute(`data-pf-error-preserve`))
     assert.equal("The preserved message", errorElement.textContent)
   })
 
@@ -77,16 +77,16 @@ suite('Fieldset Rendering', async () => {
           <input type="checkbox" name="privacy" required>
           <input type="checkbox" name="service" required>
 
-          <section id="terms-fieldset-errors" data-error-container>
+          <section id="terms-fieldset-errors" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-              <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+              <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+              <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
             </ul>
           </section>
         </fieldset>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `);
@@ -102,7 +102,7 @@ suite('Fieldset Rendering', async () => {
 
     assert.equal(1, document.querySelectorAll(`#terms-fieldset-errors li`).length)
 
-    const errorElement = document.querySelector(`#terms-fieldset-errors li[data-visible][data-error-type="required"]`)
+    const errorElement = document.querySelector(`#terms-fieldset-errors li[data-pf-error-visible][data-pf-error-type="required"]`)
 
     assert.isNotNull(errorElement)
     assert.equal("‼️ Please accept all terms", errorElement.textContent)
@@ -115,13 +115,13 @@ suite('Fieldset Rendering', async () => {
           <input type="checkbox" name="privacy" required>
           <input type="checkbox" name="service" required>
 
-          <section id="terms-fieldset-errors" data-error-container>
+          <section id="terms-fieldset-errors" data-pf-error-container>
             <ul></ul>
           </section>
         </fieldset>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `);
@@ -137,7 +137,7 @@ suite('Fieldset Rendering', async () => {
 
     assert.equal(1, document.querySelectorAll(`#terms-fieldset-errors li`).length)
 
-    const errorElement = document.querySelector(`#terms-fieldset-errors li[data-visible][data-error-type="required"]`)
+    const errorElement = document.querySelector(`#terms-fieldset-errors li[data-pf-error-visible][data-pf-error-type="required"]`)
 
     assert.isNotNull(errorElement)
     assert.equal("‼️ Please accept all terms", errorElement.textContent)
@@ -150,16 +150,16 @@ suite('Fieldset Rendering', async () => {
           <input type="checkbox" name="privacy" required>
           <input type="checkbox" name="service" required>
 
-          <section id="terms-fieldset-errors" data-error-container>
+          <section id="terms-fieldset-errors" data-pf-error-container>
             <ul>
-              <li data-preserve data-error-type="required">The preserved message</li>
-              <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+              <li data-pf-error-preserve data-pf-error-type="required">The preserved message</li>
+              <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
             </ul>
           </section>
         </fieldset>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `);
@@ -175,7 +175,7 @@ suite('Fieldset Rendering', async () => {
 
     assert.equal(1, document.querySelectorAll(`#terms-fieldset-errors li`).length)
 
-    const errorElement = document.querySelector(`#terms-fieldset-errors li[data-visible][data-error-type="required"]`)
+    const errorElement = document.querySelector(`#terms-fieldset-errors li[data-pf-error-visible][data-pf-error-type="required"]`)
 
     assert.isNotNull(errorElement)
     assert.equal("The preserved message", errorElement.textContent)

--- a/test/fieldset/util.test.js
+++ b/test/fieldset/util.test.js
@@ -152,7 +152,7 @@ suite('Event Utils: skipFieldsetChangeEvent', async () => {
   test(`skips validation`, async() => {
     const container = await fixture(html`
       <div>
-        <fieldset data-validation="skip">
+        <fieldset data-pf-validation="skip">
           <input type="checkbox">
         </fieldset>
       </div>
@@ -175,7 +175,7 @@ suite('Event Utils: skipFieldsetChangeEvent', async () => {
   test(`follows through on change validation`, async() => {
     const container = await fixture(html`
       <div>
-        <fieldset data-validation="change">
+        <fieldset data-pf-validation="change">
           <input type="checkbox">
         </fieldset>
       </div>
@@ -251,7 +251,7 @@ suite('Event Utils: skipFieldsetFocusoutEvent', async () => {
   test(`skips validation`, async() => {
     const container = await fixture(html`
       <div>
-        <fieldset data-validation="skip">
+        <fieldset data-pf-validation="skip">
           <input type="checkbox">
         </fieldset>
 
@@ -277,7 +277,7 @@ suite('Event Utils: skipFieldsetFocusoutEvent', async () => {
   test(`follows through on validation`, async() => {
     const container = await fixture(html`
       <div>
-        <fieldset data-validation="focusout">
+        <fieldset data-pf-validation="focusout">
           <input type="checkbox">
         </fieldset>
 

--- a/test/pf-error-handling.test.js
+++ b/test/pf-error-handling.test.js
@@ -9,22 +9,22 @@ suite('pf-error-handling', async () => {
         <pf-error-handling>
           <form id="test-form" aria-describedby='test-form-error-container'>
             <input type="email" id="email-field" aria-describedby="email-field-errors">
-            <section id="email-field-errors" data-error-container>
+            <section id="email-field-errors" data-pf-error-container>
               <ul>
-                <li data-visible data-error-type="error_1">ad-hoc error message 1</li>
+                <li data-pf-error-visible data-pf-error-type="error_1">ad-hoc error message 1</li>
               </ul>
             </section>
 
-            <section id="test-form-error-container" data-error-container>
+            <section id="test-form-error-container" data-pf-error-container>
               <ul>
-                <li data-visible data-error-type="error_2">ad-hoc error message 2</li>
+                <li data-pf-error-visible data-pf-error-type="error_2">ad-hoc error message 2</li>
               </ul>
             </section>
           </form>
         </pf-error-handling>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `)

--- a/test/plugins/mrujs.test.js
+++ b/test/plugins/mrujs.test.js
@@ -9,20 +9,20 @@ suite('Mrujs Plugin', async () => {
       <div>
         <form id="test-form" aria-describedby='test-form-error-container'>
           <input type="email" id="email-field" aria-describedby="email-field-errors">
-          <section id="email-field-errors" data-error-container>
+          <section id="email-field-errors" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_1">ad-hoc error message 1</li>
+              <li data-pf-error-visible data-pf-error-type="error_1">ad-hoc error message 1</li>
             </ul>
           </section>
 
-          <section id="test-form-error-container" data-error-container>
+          <section id="test-form-error-container" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_2">ad-hoc error message 2</li>
+              <li data-pf-error-visible data-pf-error-type="error_2">ad-hoc error message 2</li>
             </ul>
           </section>
         </form>
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
 
       </div>
@@ -39,7 +39,7 @@ suite('Mrujs Plugin', async () => {
 
     const form = container.querySelector(`form`)
 
-    assert.equal(2, form.querySelectorAll(`[data-error-type]`).length)
+    assert.equal(2, form.querySelectorAll(`[data-pf-error-type]`).length)
 
     const response = new Response(JSON.stringify(errors), {status: 400})
 
@@ -52,7 +52,7 @@ suite('Mrujs Plugin', async () => {
 
     await MrujsPlugins.unprocessableEntityResponseHandler(event)
 
-    assert.equal(2, form.querySelectorAll(`[data-error-type]`).length)
+    assert.equal(2, form.querySelectorAll(`[data-pf-error-type]`).length)
   })
 
   test(`applies the errors from the resonse (JSON) if response status == 422`, async () => {
@@ -60,20 +60,20 @@ suite('Mrujs Plugin', async () => {
       <div>
         <form id="test-form" aria-describedby='test-form-error-container'>
           <input type="email" id="email-field" aria-describedby="email-field-errors">
-          <section id="email-field-errors" data-error-container>
+          <section id="email-field-errors" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_1">ad-hoc error message 1</li>
+              <li data-pf-error-visible data-pf-error-type="error_1">ad-hoc error message 1</li>
             </ul>
           </section>
 
-          <section id="test-form-error-container" data-error-container>
+          <section id="test-form-error-container" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_2">ad-hoc error message 2</li>
+              <li data-pf-error-visible data-pf-error-type="error_2">ad-hoc error message 2</li>
             </ul>
           </section>
         </form>
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
 
       </div>
@@ -90,7 +90,7 @@ suite('Mrujs Plugin', async () => {
 
     const form = container.querySelector(`form`)
 
-    assert.equal(2, form.querySelectorAll(`[data-error-type]`).length)
+    assert.equal(2, form.querySelectorAll(`[data-pf-error-type]`).length)
 
     const response = new Response(JSON.stringify(errors), {status: 422})
 
@@ -103,7 +103,7 @@ suite('Mrujs Plugin', async () => {
 
     await MrujsPlugins.unprocessableEntityResponseHandler(event)
 
-    assert.equal(1, form.querySelectorAll(`[data-error-type]`).length)
-    assert.equal(1, form.querySelectorAll(`[data-error-type][data-error-type="ad_hoc_server_error_1"]`).length)
+    assert.equal(1, form.querySelectorAll(`[data-pf-error-type]`).length)
+    assert.equal(1, form.querySelectorAll(`[data-pf-error-type][data-pf-error-type="ad_hoc_server_error_1"]`).length)
   })
 })

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -6,20 +6,20 @@ suite('Rendering', async () => {
   test(`error list cleaning`, async () => {
     const errorList = await fixture(html`
       <ul>
-        <li data-visible data-error-type="error_1">An ad-hoc error 1</li>
-        <li data-visible data-error-type="error_2">An ad-hoc error 2</li>
-        <li data-visible data-error-type="custom_1" data-preserve>Preserved error 1</li>
-        <li data-error-type="custom_3" data-preserve>Preserved error 3</li>
+        <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error 1</li>
+        <li data-pf-error-visible data-pf-error-type="error_2">An ad-hoc error 2</li>
+        <li data-pf-error-visible data-pf-error-type="custom_1" data-pf-error-preserve>Preserved error 1</li>
+        <li data-pf-error-type="custom_3" data-pf-error-preserve>Preserved error 3</li>
       </ul>
     `)
 
     assert.equal(4, errorList.querySelectorAll(`li`).length)
-    assert.equal(3, errorList.querySelectorAll(`[data-visible]`).length)
+    assert.equal(3, errorList.querySelectorAll(`[data-pf-error-visible]`).length)
 
     Rendering.clearErrorList(errorList)
 
     assert.equal(2, errorList.querySelectorAll(`li`).length)
-    assert.equal(0, errorList.querySelectorAll(`[data-visible]`).length)
+    assert.equal(0, errorList.querySelectorAll(`[data-pf-error-visible]`).length)
   })
 
   test(`clearErrorListsInForm`, async() => {
@@ -27,42 +27,42 @@ suite('Rendering', async () => {
       <form aria-describedby="fallback-error-section">
         <section>
           <input type="text" id="name-field" aria-describedby="name-field-errors" required>
-            <section id="name-field-errors" data-error-container>
+            <section id="name-field-errors" data-pf-error-container>
               <ul>
-                <li data-preserve data-error-type="valueMissing">The preserved message</li>
-                <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+                <li data-pf-error-preserve data-pf-error-type="valueMissing">The preserved message</li>
+                <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
               </ul>
             </section>
         </section>
 
         <section>
           <input type="email" id="email-field" aria-describedby="email-field-errors" required>
-            <section id="email-field-errors" data-error-container>
+            <section id="email-field-errors" data-pf-error-container>
               <ul>
-                <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-                <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+                <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+                <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
               </ul>
             </section>
         </section>
 
-        <section id="fallback-error-section" data-error-container>
+        <section id="fallback-error-section" data-pf-error-container>
           <ul>
-            <li data-visible data-error-type="error_1">An ad-hoc fallback error 1</li>
-            <li data-visible data-error-type="custom_1" data-preserve>Preserved fallback error</li>
+            <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc fallback error 1</li>
+            <li data-pf-error-visible data-pf-error-type="custom_1" data-pf-error-preserve>Preserved fallback error</li>
           </ul>
         </section>
       </form>
     `)
 
-    assert.equal(2, document.querySelectorAll(`#name-field-errors [data-error-type]`).length)
-    assert.equal(2, document.querySelectorAll(`#email-field-errors [data-error-type]`).length)
-    assert.equal(2, document.querySelectorAll(`#fallback-error-section [data-error-type]`).length)
+    assert.equal(2, document.querySelectorAll(`#name-field-errors [data-pf-error-type]`).length)
+    assert.equal(2, document.querySelectorAll(`#email-field-errors [data-pf-error-type]`).length)
+    assert.equal(2, document.querySelectorAll(`#fallback-error-section [data-pf-error-type]`).length)
 
     Rendering.clearErrorListsInForm(form)
 
-    assert.equal(1, document.querySelectorAll(`#name-field-errors [data-error-type]`).length)
-    assert.equal(0, document.querySelectorAll(`#email-field-errors [data-error-type]`).length)
-    assert.equal(1, document.querySelectorAll(`#fallback-error-section [data-error-type]`).length)
+    assert.equal(1, document.querySelectorAll(`#name-field-errors [data-pf-error-type]`).length)
+    assert.equal(0, document.querySelectorAll(`#email-field-errors [data-pf-error-type]`).length)
+    assert.equal(1, document.querySelectorAll(`#fallback-error-section [data-pf-error-type]`).length)
   })
 
   test(`errorMessageListItem`, async() => {
@@ -71,35 +71,35 @@ suite('Rendering', async () => {
         <p>Some content</p>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `)
 
     const itemElement = Rendering.errorMessageListItem("An error message", "a-custom-type")
 
-    assert.equal("a-custom-type", itemElement.getAttribute(`data-error-type`))
-    assert.equal("An error message", itemElement.querySelector(`[data-error-message]`).textContent)
+    assert.equal("a-custom-type", itemElement.getAttribute(`data-pf-error-type`))
+    assert.equal("An error message", itemElement.querySelector(`[data-pf-error-message]`).textContent)
     assert.equal("‼️ An error message", itemElement.textContent)
-    assert.equal(false, itemElement.hasAttribute(`data-preserve`))
+    assert.equal(false, itemElement.hasAttribute(`data-pf-error-preserve`))
 
-    itemElement.setAttribute(`data-preserve`, true)
-    assert.equal(true, itemElement.hasAttribute(`data-preserve`))
+    itemElement.setAttribute(`data-pf-error-preserve`, true)
+    assert.equal(true, itemElement.hasAttribute(`data-pf-error-preserve`))
   })
 
   test(`renderConstraintValidationMessageForElement: the input is valid`, async () => {
     const container = await fixture(html`
       <div>
         <input type="text" id="name-field" aria-describedby="name-field-errors" required>
-        <section id="name-field-errors" data-error-container>
+        <section id="name-field-errors" data-pf-error-container>
           <ul>
-            <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-            <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+            <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+            <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
           </ul>
         </section>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `);
@@ -114,7 +114,7 @@ suite('Rendering', async () => {
 
     assert.equal(1, document.querySelectorAll(`#name-field-errors li`).length)
 
-    const errorElement = document.querySelector(`#name-field-errors li[data-visible][data-error-type="valueMissing"]`)
+    const errorElement = document.querySelector(`#name-field-errors li[data-pf-error-visible][data-pf-error-type="valueMissing"]`)
 
     assert.isNotNull(errorElement)
     assert.equal("‼️ Please fill out this field.", errorElement.textContent)
@@ -129,15 +129,15 @@ suite('Rendering', async () => {
     const container = await fixture(html`
       <div>
         <input type="text" id="name-field" aria-describedby="name-field-errors" required>
-        <section id="name-field-errors" data-error-container>
+        <section id="name-field-errors" data-pf-error-container>
           <ul>
-            <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-            <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+            <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+            <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
           </ul>
         </section>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `);
@@ -152,7 +152,7 @@ suite('Rendering', async () => {
 
     assert.equal(1, document.querySelectorAll(`#name-field-errors li`).length)
 
-    const errorElement = document.querySelector(`#name-field-errors li[data-visible][data-error-type="valueMissing"]`)
+    const errorElement = document.querySelector(`#name-field-errors li[data-pf-error-visible][data-pf-error-type="valueMissing"]`)
 
     assert.isNotNull(errorElement)
     assert.equal("‼️ Please fill out this field.", errorElement.textContent)
@@ -162,12 +162,12 @@ suite('Rendering', async () => {
     const container = await fixture(html`
       <div>
         <input type="text" id="name-field" aria-describedby="name-field-errors" required>
-        <section id="name-field-errors" data-error-container>
+        <section id="name-field-errors" data-pf-error-container>
           <ul></ul>
         </section>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `);
@@ -182,7 +182,7 @@ suite('Rendering', async () => {
 
     assert.equal(1, document.querySelectorAll(`#name-field-errors li`).length)
 
-    const errorElement = document.querySelector(`#name-field-errors li[data-visible][data-error-type="valueMissing"]`)
+    const errorElement = document.querySelector(`#name-field-errors li[data-pf-error-visible][data-pf-error-type="valueMissing"]`)
 
     assert.isNotNull(errorElement)
     assert.equal("‼️ Please fill out this field.", errorElement.textContent)
@@ -192,15 +192,15 @@ suite('Rendering', async () => {
     const container = await fixture(html`
       <div>
         <input type="text" id="name-field" aria-describedby="name-field-errors" required>
-        <section id="name-field-errors" data-error-container>
+        <section id="name-field-errors" data-pf-error-container>
           <ul>
-            <li data-preserve data-error-type="valueMissing">The preserved message</li>
-            <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+            <li data-pf-error-preserve data-pf-error-type="valueMissing">The preserved message</li>
+            <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
           </ul>
         </section>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `);
@@ -215,25 +215,25 @@ suite('Rendering', async () => {
 
     assert.equal(1, document.querySelectorAll(`#name-field-errors li`).length)
 
-    const errorElement = document.querySelector(`#name-field-errors li[data-visible][data-error-type="valueMissing"]`)
+    const errorElement = document.querySelector(`#name-field-errors li[data-pf-error-visible][data-pf-error-type="valueMissing"]`)
 
     assert.isNotNull(errorElement)
     assert.equal("The preserved message", errorElement.textContent)
   })
 
-  test(`renderConstraintValidationMessageForElement: keeps the given preserved message, removing the data-visible attribute`, async () => {
+  test(`renderConstraintValidationMessageForElement: keeps the given preserved message, removing the data-pf-error-visible attribute`, async () => {
     const container = await fixture(html`
       <div>
         <input type="text" id="name-field" aria-describedby="name-field-errors" required>
-        <section id="name-field-errors" data-error-container>
+        <section id="name-field-errors" data-pf-error-container>
           <ul>
-            <li data-preserve data-error-type="valueMissing">The preserved message</li>
-            <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+            <li data-pf-error-preserve data-pf-error-type="valueMissing">The preserved message</li>
+            <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
           </ul>
         </section>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `);
@@ -248,7 +248,7 @@ suite('Rendering', async () => {
 
     assert.equal(1, document.querySelectorAll(`#name-field-errors li`).length)
 
-    const errorElement = document.querySelector(`#name-field-errors li[data-visible][data-error-type="valueMissing"]`)
+    const errorElement = document.querySelector(`#name-field-errors li[data-pf-error-visible][data-pf-error-type="valueMissing"]`)
 
     assert.isNotNull(errorElement)
     assert.equal("The preserved message", errorElement.textContent)
@@ -259,8 +259,8 @@ suite('Rendering', async () => {
 
     assert.equal(1, document.querySelectorAll(`#name-field-errors li`).length)
 
-    assert.equal(false, errorElement.hasAttribute(`data-visible`))
-    assert.equal(true, errorElement.hasAttribute(`data-preserve`))
+    assert.equal(false, errorElement.hasAttribute(`data-pf-error-visible`))
+    assert.equal(true, errorElement.hasAttribute(`data-pf-error-preserve`))
     assert.equal("The preserved message", errorElement.textContent)
   })
 })
@@ -272,16 +272,16 @@ suite(`renderConstraintValidationMessageForElement: different input types`, asyn
         <fieldset>
           <input type="radio" name="terms" id="terms-field-privacy" value="privacy" aria-describedby="terms-field-errors" required>
           <input type="radio" name="terms" id="terms-field-service" value="service" aria-describedby="terms-field-errors">
-          <section id="terms-field-errors" data-error-container>
+          <section id="terms-field-errors" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-              <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+              <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+              <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
             </ul>
           </section>
         </fieldset>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `);
@@ -299,7 +299,7 @@ suite(`renderConstraintValidationMessageForElement: different input types`, asyn
 
     assert.equal(1, document.querySelectorAll(`#terms-field-errors li`).length)
 
-    const errorElement = document.querySelector(`#terms-field-errors li[data-visible][data-error-type="valueMissing"]`)
+    const errorElement = document.querySelector(`#terms-field-errors li[data-pf-error-visible][data-pf-error-type="valueMissing"]`)
 
     assert.isNotNull(errorElement)
     assert.equal("‼️ Please select one of these options.", errorElement.textContent)
@@ -318,16 +318,16 @@ suite(`renderConstraintValidationMessageForElement: different input types`, asyn
         <fieldset>
           <input type="checkbox" name="terms" id="terms-field-privacy" value="privacy" aria-describedby="terms-field-errors" required>
           <input type="checkbox" name="terms" id="terms-field-service" value="service" aria-describedby="terms-field-errors" required>
-          <section id="terms-field-errors" data-error-container>
+          <section id="terms-field-errors" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-              <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+              <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+              <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
             </ul>
           </section>
         </fieldset>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `);
@@ -345,7 +345,7 @@ suite(`renderConstraintValidationMessageForElement: different input types`, asyn
 
     assert.equal(1, document.querySelectorAll(`#terms-field-errors li`).length)
 
-    const errorElement = document.querySelector(`#terms-field-errors li[data-visible][data-error-type="valueMissing"]`)
+    const errorElement = document.querySelector(`#terms-field-errors li[data-pf-error-visible][data-pf-error-type="valueMissing"]`)
 
     assert.isNotNull(errorElement)
     assert.equal("‼️ Please check this box if you want to proceed.", errorElement.textContent)
@@ -364,23 +364,23 @@ suite(`renderConstraintValidationMessageForElement: different input types`, asyn
         <fieldset>
           <input type="checkbox" name="terms" id="terms-field-privacy" value="privacy" aria-describedby="terms-privacy-errors" required>
           <input type="checkbox" name="terms" id="terms-field-service" value="service" aria-describedby="terms-service-errors" required>
-          <section id="terms-privacy-errors" data-error-container>
+          <section id="terms-privacy-errors" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-              <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+              <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+              <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
             </ul>
           </section>
 
-          <section id="terms-service-errors" data-error-container>
+          <section id="terms-service-errors" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_1">An ad-hoc error from the initial load</li>
-              <li data-visible data-error-type="error_2">Another ad-hoc error from the initial load</li>
+              <li data-pf-error-visible data-pf-error-type="error_1">An ad-hoc error from the initial load</li>
+              <li data-pf-error-visible data-pf-error-type="error_2">Another ad-hoc error from the initial load</li>
             </ul>
           </section>
         </fieldset>
 
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
       </div>
     `);
@@ -399,7 +399,7 @@ suite(`renderConstraintValidationMessageForElement: different input types`, asyn
     assert.equal(1, document.querySelectorAll(`#terms-privacy-errors li`).length)
     assert.equal(2, document.querySelectorAll(`#terms-service-errors li`).length)
 
-    const errorElement = document.querySelector(`#terms-privacy-errors li[data-visible][data-error-type="valueMissing"]`)
+    const errorElement = document.querySelector(`#terms-privacy-errors li[data-pf-error-visible][data-pf-error-type="valueMissing"]`)
 
     assert.isNotNull(errorElement)
     assert.equal("‼️ Please check this box if you want to proceed.", errorElement.textContent)

--- a/test/request-processing.test.js
+++ b/test/request-processing.test.js
@@ -9,20 +9,20 @@ suite('Request Processing', async () => {
       <div>
         <form id="test-form" aria-describedby='test-form-error-container'>
           <input type="email" id="email-field" aria-describedby="email-field-errors">
-          <section id="email-field-errors" data-error-container>
+          <section id="email-field-errors" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_1">ad-hoc error message 1</li>
+              <li data-pf-error-visible data-pf-error-type="error_1">ad-hoc error message 1</li>
             </ul>
           </section>
 
-          <section id="test-form-error-container" data-error-container>
+          <section id="test-form-error-container" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_2">ad-hoc error message 2</li>
+              <li data-pf-error-visible data-pf-error-type="error_2">ad-hoc error message 2</li>
             </ul>
           </section>
         </form>
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
 
       </div>
@@ -39,13 +39,13 @@ suite('Request Processing', async () => {
 
     const form = container.querySelector(`form`)
 
-    assert.equal(2, form.querySelectorAll(`[data-error-type]`).length)
+    assert.equal(2, form.querySelectorAll(`[data-pf-error-type]`).length)
 
     const response = new Response(JSON.stringify(errors), {status: 400})
 
     await RequestProcessing.applyErrorMappingToFormFromUnprocessableEntityResponseResponse(form, response)
 
-    assert.equal(2, form.querySelectorAll(`[data-error-type]`).length)
+    assert.equal(2, form.querySelectorAll(`[data-pf-error-type]`).length)
   })
 
   test(`applies the errors from the resonse (JSON) if response status == 422`, async () => {
@@ -53,20 +53,20 @@ suite('Request Processing', async () => {
       <div>
         <form id="test-form" aria-describedby='test-form-error-container'>
           <input type="email" id="email-field" aria-describedby="email-field-errors">
-          <section id="email-field-errors" data-error-container>
+          <section id="email-field-errors" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_1">ad-hoc error message 1</li>
+              <li data-pf-error-visible data-pf-error-type="error_1">ad-hoc error message 1</li>
             </ul>
           </section>
 
-          <section id="test-form-error-container" data-error-container>
+          <section id="test-form-error-container" data-pf-error-container>
             <ul>
-              <li data-visible data-error-type="error_2">ad-hoc error message 2</li>
+              <li data-pf-error-visible data-pf-error-type="error_2">ad-hoc error message 2</li>
             </ul>
           </section>
         </form>
         <template id="pf-error-list-item-template">
-          <li><span>‼️</span> <span data-error-message></span></li>
+          <li><span>‼️</span> <span data-pf-error-message></span></li>
         </template>
 
       </div>
@@ -83,13 +83,13 @@ suite('Request Processing', async () => {
 
     const form = container.querySelector(`form`)
 
-    assert.equal(2, form.querySelectorAll(`[data-error-type]`).length)
+    assert.equal(2, form.querySelectorAll(`[data-pf-error-type]`).length)
 
     const response = new Response(JSON.stringify(errors), {status: 422})
 
     await RequestProcessing.applyErrorMappingToFormFromUnprocessableEntityResponseResponse(form, response)
 
-    assert.equal(1, form.querySelectorAll(`[data-error-type]`).length)
-    assert.equal(1, form.querySelectorAll(`[data-error-type][data-error-type="ad_hoc_server_error_1"]`).length)
+    assert.equal(1, form.querySelectorAll(`[data-pf-error-type]`).length)
+    assert.equal(1, form.querySelectorAll(`[data-pf-error-type][data-pf-error-type="ad_hoc_server_error_1"]`).length)
   })
 })


### PR DESCRIPTION
* Prefixing all the `data` attributes with `data-pf` helps clarify what markup is used as part of the Practical Framework error handling
* This also has the benefit of reducing collisions with existing error handling frameworks in an existing application